### PR TITLE
remove unused imports from ServiceSpec

### DIFF
--- a/$name__norm$-impl/src/test/scala/$organization__packaged$/$name__camel$/impl/$name__Camel$ServiceSpec.scala
+++ b/$name__norm$-impl/src/test/scala/$organization__packaged$/$name__camel$/impl/$name__Camel$ServiceSpec.scala
@@ -1,8 +1,5 @@
 package $organization$.$name;format="camel"$.impl
 
-import java.io.File
-
-import akka.cluster.Cluster
 import com.lightbend.lagom.scaladsl.server.LocalServiceLocator
 import com.lightbend.lagom.scaladsl.testkit.ServiceTest
 import org.scalatest.{AsyncWordSpec, BeforeAndAfterAll, Matchers}


### PR DESCRIPTION
the imports for java.io.File and akka.cluster.Cluster are unused so we can remove them safely.