### PR TITLE
Strip non-word characters from the keyspace name

### DIFF
--- a/$name__norm$-impl/src/main/resources/application.conf
+++ b/$name__norm$-impl/src/main/resources/application.conf
@@ -4,7 +4,7 @@
 play.crypto.secret = whatever
 play.application.loader = $organization$.$name;format="camel"$.impl.$name;format="Camel"$Loader
 
-$name;format="norm"$.cassandra.keyspace = $name;format="lower,snake"$
+$name;format="norm"$.cassandra.keyspace = $name;format="lower,snake,word"$
 
 $!
 The unusual syntax below is because this file is proccessed by StringTemplate.


### PR DESCRIPTION
Fixes #5