### PR TITLE
Update Lagom to 1.3.6

### DIFF
--- a/src/main/g8/$name__norm$-impl/src/main/scala/$package$/impl/$name__Camel$Loader.scala
+++ b/src/main/g8/$name__norm$-impl/src/main/scala/$package$/impl/$name__Camel$Loader.scala
@@ -20,9 +20,7 @@ class $name;format="Camel"$Loader extends LagomApplicationLoader {
   override def loadDevMode(context: LagomApplicationContext): LagomApplication =
     new $name;format="Camel"$Application(context) with LagomDevModeComponents
 
-  override def describeServices = List(
-    readDescriptor[$name;format="Camel"$Service]
-  )
+  override def describeService = Some(readDescriptor[$name;format="Camel"$Service])
 }
 
 abstract class $name;format="Camel"$Application(context: LagomApplicationContext)

--- a/src/main/g8/$name__norm$-stream-impl/src/main/scala/$package$stream/impl/$name__Camel$StreamLoader.scala
+++ b/src/main/g8/$name__norm$-stream-impl/src/main/scala/$package$stream/impl/$name__Camel$StreamLoader.scala
@@ -18,9 +18,7 @@ class $name;format="Camel"$StreamLoader extends LagomApplicationLoader {
   override def loadDevMode(context: LagomApplicationContext): LagomApplication =
     new $name;format="Camel"$StreamApplication(context) with LagomDevModeComponents
   
-  override def describeServices = List(
-    readDescriptor[$name;format="Camel"$StreamService]
-  )
+  override def describeService = Some(readDescriptor[$name;format="Camel"$StreamService])
 }
 
 abstract class $name;format="Camel"$StreamApplication(context: LagomApplicationContext)

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,5 +1,5 @@
 name = Hello
 organization = com.example
 version = 1.0-SNAPSHOT
-lagom_version = 1.3.5
+lagom_version = 1.3.6
 package = $organization$.$name;format="lower,word"$


### PR DESCRIPTION
Also updates overrides of `describeServices` (which is deprecated) to override `describeService` instead.

Fixes #13 