### PR TITLE
Defaulting to Lagom 1.4.0-RC1

### DIFF
--- a/src/main/g8/$name__norm$-api/src/main/scala/$package$/api/$name__Camel$Service.scala
+++ b/src/main/g8/$name__norm$-api/src/main/scala/$package$/api/$name__Camel$Service.scala
@@ -44,7 +44,7 @@ trait $name;format="Camel"$Service extends Service {
         pathCall("/api/hello/:id", useGreeting _)
       )
       .withTopics(
-        topic($name;format="Camel"$Service.TOPIC_NAME, greetingsTopic _)
+        topic($name;format="Camel"$Service.TOPIC_NAME, greetingsTopic)
           // Kafka partitions messages, messages within the same partition will
           // be delivered in order, to ensure that all messages for the same user
           // go to the same partition (and hence are delivered in order with respect

--- a/src/main/g8/$name__norm$-impl/src/main/resources/application.conf
+++ b/src/main/g8/$name__norm$-impl/src/main/resources/application.conf
@@ -21,3 +21,17 @@ Also note that this comment is a StringTemplate comment and is not included in t
 cassandra-journal.keyspace = \${$name;format="norm"$.cassandra.keyspace}
 cassandra-snapshot-store.keyspace = \${$name;format="norm"$.cassandra.keyspace}
 lagom.persistence.read-side.cassandra.keyspace = \${$name;format="norm"$.cassandra.keyspace}
+
+
+# The properties below override Lagom default configuration with the recommended values for new projects.
+#
+# Lagom has not yet made these settings the defaults for backward-compatibility reasons.
+
+# Prefer 'ddata' over 'persistence' to share cluster sharding state for new projects.
+# See https://doc.akka.io/docs/akka/current/cluster-sharding.html#distributed-data-vs-persistence-mode
+akka.cluster.sharding.state-store-mode = ddata
+
+# Enable the serializer for akka.Done provided in Akka 2.5.8+ to avoid the use of Java serialization.
+akka.actor.serialization-bindings {
+  "akka.Done" = akka-misc
+}

--- a/src/main/g8/$name__norm$-impl/src/main/resources/application.conf
+++ b/src/main/g8/$name__norm$-impl/src/main/resources/application.conf
@@ -1,6 +1,5 @@
 #
 #
-play.crypto.secret = whatever
 play.application.loader = $package$.impl.$name;format="Camel"$Loader
 
 $name;format="norm"$.cassandra.keyspace = $name;format="lower,snake,word"$

--- a/src/main/g8/$name__norm$-stream-impl/src/main/resources/application.conf
+++ b/src/main/g8/$name__norm$-stream-impl/src/main/resources/application.conf
@@ -1,1 +1,15 @@
 play.application.loader = $package$stream.impl.$name;format="Camel"$StreamLoader
+
+
+# The properties below override Lagom default configuration with the recommended values for new projects.
+#
+# Lagom has not yet made these settings the defaults for backward-compatibility reasons.
+
+# Prefer 'ddata' over 'persistence' to share cluster sharding state for new projects.
+# See https://doc.akka.io/docs/akka/current/cluster-sharding.html#distributed-data-vs-persistence-mode
+akka.cluster.sharding.state-store-mode = ddata
+
+# Enable the serializer for akka.Done provided in Akka 2.5.8+ to avoid the use of Java serialization.
+akka.actor.serialization-bindings {
+  "akka.Done" = akka-misc
+}

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -2,7 +2,7 @@ organization in ThisBuild := "$organization$"
 version in ThisBuild := "$version$"
 
 // the Scala version that will be used for cross-compiled libraries
-scalaVersion in ThisBuild := "2.11.8"
+scalaVersion in ThisBuild := "2.12.4"
 
 val macwire = "com.softwaremill.macwire" %% "macros" % "2.2.5" % "provided"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1" % Test

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -4,8 +4,8 @@ version in ThisBuild := "$version$"
 // the Scala version that will be used for cross-compiled libraries
 scalaVersion in ThisBuild := "2.12.4"
 
-val macwire = "com.softwaremill.macwire" %% "macros" % "2.2.5" % "provided"
-val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1" % Test
+val macwire = "com.softwaremill.macwire" %% "macros" % "2.3.0" % "provided"
+val scalaTest = "org.scalatest" %% "scalatest" % "3.0.4" % Test
 
 lazy val `$name;format="norm"$` = (project in file("."))
   .aggregate(`$name;format="norm"$-api`, `$name;format="norm"$-impl`, `$name;format="normalize"$-stream-api`, `$name;format="normalize"$-stream-impl`)

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,5 +1,5 @@
 name = Hello
 organization = com.example
 version = 1.0-SNAPSHOT
-lagom_version = 1.3.10
+lagom_version = 1.4.0-RC1
 package = $organization$.$name;format="lower,word"$


### PR DESCRIPTION
* defaults to Scala 2.12.4
* updates macwire to 2.3.0
* updates ScalaTest to 3.0.4
* recommend properties overrides