### PR TITLE
Cleanup warnings, change default name

### DIFF
--- a/src/main/g8/$name__norm$-api/src/main/scala/$package$/api/$name__Camel$Service.scala
+++ b/src/main/g8/$name__norm$-api/src/main/scala/$package$/api/$name__Camel$Service.scala
@@ -3,7 +3,7 @@ package $package$.api
 import akka.{Done, NotUsed}
 import com.lightbend.lagom.scaladsl.api.broker.Topic
 import com.lightbend.lagom.scaladsl.api.broker.kafka.{KafkaProperties, PartitionKeyStrategy}
-import com.lightbend.lagom.scaladsl.api.{Service, ServiceCall}
+import com.lightbend.lagom.scaladsl.api.{Descriptor, Service, ServiceCall}
 import play.api.libs.json.{Format, Json}
 
 object $name;format="Camel"$Service  {
@@ -35,7 +35,7 @@ trait $name;format="Camel"$Service extends Service {
     */
   def greetingsTopic(): Topic[GreetingMessageChanged]
 
-  override final def descriptor = {
+  override final def descriptor: Descriptor = {
     import Service._
     // @formatter:off
     named("$name;format="norm"$")

--- a/src/main/g8/$name__norm$-api/src/main/scala/$package$/api/$name__Camel$Service.scala
+++ b/src/main/g8/$name__norm$-api/src/main/scala/$package$/api/$name__Camel$Service.scala
@@ -44,7 +44,7 @@ trait $name;format="Camel"$Service extends Service {
         pathCall("/api/hello/:id", useGreeting _)
       )
       .withTopics(
-        topic($name;format="Camel"$Service.TOPIC_NAME, greetingsTopic)
+        topic($name;format="Camel"$Service.TOPIC_NAME, greetingsTopic _)
           // Kafka partitions messages, messages within the same partition will
           // be delivered in order, to ensure that all messages for the same user
           // go to the same partition (and hence are delivered in order with respect

--- a/src/main/g8/$name__norm$-impl/src/main/scala/$package$/impl/$name__Camel$Entity.scala
+++ b/src/main/g8/$name__norm$-impl/src/main/scala/$package$/impl/$name__Camel$Entity.scala
@@ -100,11 +100,11 @@ object $name;format="Camel"$State {
   * This interface defines all the events that the $name;format="Camel"$Entity supports.
   */
 sealed trait $name;format="Camel"$Event extends AggregateEvent[$name;format="Camel"$Event] {
-  def aggregateTag = $name;format="Camel"$Event.Tag
+  def aggregateTag: AggregateEventTag[$name;format="Camel"$Event] = $name;format="Camel"$Event.Tag
 }
 
 object $name;format="Camel"$Event {
-  val Tag = AggregateEventTag[$name;format="Camel"$Event]
+  val Tag: AggregateEventTag[$name;format="Camel"$Event] = AggregateEventTag[$name;format="Camel"$Event]
 }
 
 /**

--- a/src/main/g8/$name__norm$-impl/src/main/scala/$package$/impl/$name__Camel$Loader.scala
+++ b/src/main/g8/$name__norm$-impl/src/main/scala/$package$/impl/$name__Camel$Loader.scala
@@ -8,6 +8,7 @@ import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
 import play.api.libs.ws.ahc.AhcWSComponents
 import $package$.api.$name;format="Camel"$Service
 import com.lightbend.lagom.scaladsl.broker.kafka.LagomKafkaComponents
+import com.lightbend.lagom.scaladsl.playjson.JsonSerializerRegistry
 import com.softwaremill.macwire._
 
 class $name;format="Camel"$Loader extends LagomApplicationLoader {
@@ -30,10 +31,10 @@ abstract class $name;format="Camel"$Application(context: LagomApplicationContext
     with AhcWSComponents {
 
   // Bind the service that this server provides
-  override lazy val lagomServer = serverFor[$name;format="Camel"$Service](wire[$name;format="Camel"$ServiceImpl])
+  override lazy val lagomServer: LagomServer = serverFor[$name;format="Camel"$Service](wire[$name;format="Camel"$ServiceImpl])
 
   // Register the JSON serializer registry
-  override lazy val jsonSerializerRegistry = $name;format="Camel"$SerializerRegistry
+  override lazy val jsonSerializerRegistry: JsonSerializerRegistry = $name;format="Camel"$SerializerRegistry
 
   // Register the $name$ persistent entity
   persistentEntityRegistry.register(wire[$name;format="Camel"$Entity])

--- a/src/main/g8/$name__norm$-impl/src/main/scala/$package$/impl/$name__Camel$ServiceImpl.scala
+++ b/src/main/g8/$name__norm$-impl/src/main/scala/$package$/impl/$name__Camel$ServiceImpl.scala
@@ -1,7 +1,7 @@
 package $package$.impl
 
 import $package$.api
-import $package$.api.{$name;format="Camel"$Service}
+import $package$.api.$name;format="Camel"$Service
 import com.lightbend.lagom.scaladsl.api.ServiceCall
 import com.lightbend.lagom.scaladsl.api.broker.Topic
 import com.lightbend.lagom.scaladsl.broker.TopicProducer

--- a/src/main/g8/$name__norm$-impl/src/test/scala/$package$/impl/$name__Camel$ServiceSpec.scala
+++ b/src/main/g8/$name__norm$-impl/src/test/scala/$package$/impl/$name__Camel$ServiceSpec.scala
@@ -14,9 +14,9 @@ class $name;format="Camel"$ServiceSpec extends AsyncWordSpec with Matchers with 
     new $name;format="Camel"$Application(ctx) with LocalServiceLocator
   }
 
-  val client = server.serviceClient.implement[$name;format="Camel"$Service]
+  val client: $name;format="Camel"$Service = server.serviceClient.implement[$name;format="Camel"$Service]
 
-  override protected def afterAll() = server.stop()
+  override protected def afterAll(): Unit = server.stop()
 
   "$name$ service" should {
 

--- a/src/main/g8/$name__norm$-stream-api/src/main/scala/$package$stream/api/$name__Camel$StreamService.scala
+++ b/src/main/g8/$name__norm$-stream-api/src/main/scala/$package$stream/api/$name__Camel$StreamService.scala
@@ -2,7 +2,7 @@ package $package$stream.api
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import com.lightbend.lagom.scaladsl.api.{Service, ServiceCall}
+import com.lightbend.lagom.scaladsl.api.{Descriptor, Service, ServiceCall}
 
 /**
   * The $name$ stream interface.
@@ -14,7 +14,7 @@ trait $name;format="Camel"$StreamService extends Service {
 
   def stream: ServiceCall[Source[String, NotUsed], Source[String, NotUsed]]
 
-  override final def descriptor = {
+  override final def descriptor: Descriptor = {
     import Service._
 
     named("$name;format="norm"$-stream")

--- a/src/main/g8/$name__norm$-stream-impl/src/main/scala/$package$stream/impl/$name__Camel$StreamLoader.scala
+++ b/src/main/g8/$name__norm$-stream-impl/src/main/scala/$package$stream/impl/$name__Camel$StreamLoader.scala
@@ -12,12 +12,12 @@ class $name;format="Camel"$StreamLoader extends LagomApplicationLoader {
 
   override def load(context: LagomApplicationContext): LagomApplication =
     new $name;format="Camel"$StreamApplication(context) {
-      override def serviceLocator = NoServiceLocator
+      override def serviceLocator: NoServiceLocator.type = NoServiceLocator
     }
 
   override def loadDevMode(context: LagomApplicationContext): LagomApplication =
     new $name;format="Camel"$StreamApplication(context) with LagomDevModeComponents
-  
+
   override def describeService = Some(readDescriptor[$name;format="Camel"$StreamService])
 }
 
@@ -26,8 +26,8 @@ abstract class $name;format="Camel"$StreamApplication(context: LagomApplicationC
     with AhcWSComponents {
 
   // Bind the service that this server provides
-  override lazy val lagomServer = serverFor[$name;format="Camel"$StreamService](wire[$name;format="Camel"$StreamServiceImpl])
+  override lazy val lagomServer: LagomServer = serverFor[$name;format="Camel"$StreamService](wire[$name;format="Camel"$StreamServiceImpl])
 
   // Bind the $name;format="Camel"$Service client
-  lazy val $name;format="camel"$Service = serviceClient.implement[$name;format="Camel"$Service]
+  lazy val $name;format="camel"$Service: $name;format="Camel"$Service = serviceClient.implement[$name;format="Camel"$Service]
 }

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,4 +1,4 @@
-name = Hello
+name = Hello World
 organization = com.example
 version = 1.0-SNAPSHOT
 package = $organization$.$name;format="lower,word"$


### PR DESCRIPTION
1. Newly generated projects report a number of warnings, this cleans those up.
2. For new users wanting to generate a project with a name consisting of more than one word, it might not be apparent that the name should be specified as spaced words (i.e., "Hello World" vs. "HelloWorld"). Specifying "HelloWorld" produces potentially confusing output, such as `HelloworldService`, where `HelloWorldService` is likely what was intended. This changes the default name of the project from "Hello" to "Hello World" to demonstrate the appropriate way to specify projects with a multiword name.